### PR TITLE
Fix order mismatch & duplicates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
+        "async-lock": "^1.3.1",
         "file-type": "^16.5.3",
         "filenamify": "github:aleksey-rezvov/filenamify",
         "got": "^11.8.2",
@@ -23,6 +24,7 @@
         "@rollup/plugin-commonjs": "^18.0.0",
         "@rollup/plugin-node-resolve": "^11.2.1",
         "@rollup/plugin-typescript": "^8.2.1",
+        "@types/async-lock": "^1.1.5",
         "@types/node": "^14.14.37",
         "@types/safe-regex": "^1.1.2",
         "json": "^11.0.0",
@@ -210,6 +212,12 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/@types/async-lock": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmmirror.com/@types/async-lock/-/async-lock-1.1.5.tgz",
+      "integrity": "sha512-A9ClUfmj6wwZMLRz0NaYzb98YH1exlHdf/cdDSKBfMQJnPOdO8xlEW0Eh2QsTTntGzOFWURcEjYElkZ1IY4GCQ==",
+      "dev": true
+    },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
@@ -317,6 +325,11 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
+    },
+    "node_modules/async-lock": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmmirror.com/async-lock/-/async-lock-1.3.1.tgz",
+      "integrity": "sha512-zK7xap9UnttfbE23JmcrNIyueAn6jWshihJqA33U/hEnKprF/lVGBDsBv/bqLm2YMMl1DnpHhUY044eA0t1TUw=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -3968,6 +3981,12 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "@types/async-lock": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmmirror.com/@types/async-lock/-/async-lock-1.1.5.tgz",
+      "integrity": "sha512-A9ClUfmj6wwZMLRz0NaYzb98YH1exlHdf/cdDSKBfMQJnPOdO8xlEW0Eh2QsTTntGzOFWURcEjYElkZ1IY4GCQ==",
+      "dev": true
+    },
     "@types/cacheable-request": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",
@@ -4066,6 +4085,11 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
+    },
+    "async-lock": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmmirror.com/async-lock/-/async-lock-1.3.1.tgz",
+      "integrity": "sha512-zK7xap9UnttfbE23JmcrNIyueAn6jWshihJqA33U/hEnKprF/lVGBDsBv/bqLm2YMMl1DnpHhUY044eA0t1TUw=="
     },
     "balanced-match": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@rollup/plugin-commonjs": "^18.0.0",
     "@rollup/plugin-node-resolve": "^11.2.1",
     "@rollup/plugin-typescript": "^8.2.1",
+    "@types/async-lock": "^1.1.5",
     "@types/node": "^14.14.37",
     "@types/safe-regex": "^1.1.2",
     "json": "^11.0.0",
@@ -27,6 +28,7 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
+    "async-lock": "^1.3.1",
     "file-type": "^16.5.3",
     "filenamify": "github:aleksey-rezvov/filenamify",
     "got": "^11.8.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 export const FILENAME_TEMPLATE = "media";
 
-export const MAX_FILENAME_INDEX = 1000;
+export const MAX_FILENAME_SUFFIX_LEN = 10;
 
 export const FILENAME_ATTEMPTS = 5;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,20 +11,13 @@ It will be better to do it type-correct.
 
 */
 export async function replaceAsync(str: any, regex: any, asyncFn: any) {
-  const remotes: string[] = [];
   const promises: Promise<any>[] = [];
   str.replace(regex, (match: string, ...args: any) => {
-    remotes.push(match);
-    promises.push(asyncFn(match, ...args));
+    const promise = asyncFn(match, ...args);
+    promises.push(promise);
   });
   const data = await Promise.all(promises);
-  const remote2local = new Map();
-  remotes.map((remote, i) => {
-    remote2local.set(remote, data[i]);
-  });
-  return str.replace(regex, (match: string) => {
-    return remote2local.get(match);
-  });
+  return str.replace(regex, () => data.shift());
 }
 
 export function isUrl(link: string) {
@@ -73,4 +66,8 @@ export function pathJoin(dir: string, subpath: string): string {
   const result = path.join(dir, subpath);
   // it seems that obsidian do not understand paths with backslashes in Windows, so turn them into forward slashes
   return result.replace(/\\/g, "/");
+}
+
+export function genRandomStr(length: number): string {
+  return Array(length).fill(null).map(()=>"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".charAt(Math.random()*62)).join("");
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,13 +11,20 @@ It will be better to do it type-correct.
 
 */
 export async function replaceAsync(str: any, regex: any, asyncFn: any) {
+  const remotes: string[] = [];
   const promises: Promise<any>[] = [];
   str.replace(regex, (match: string, ...args: any) => {
-    const promise = asyncFn(match, ...args);
-    promises.push(promise);
+    remotes.push(match);
+    promises.push(asyncFn(match, ...args));
   });
   const data = await Promise.all(promises);
-  return str.replace(regex, () => data.shift());
+  const remote2local = new Map();
+  remotes.map((remote, i) => {
+    remote2local.set(remote, data[i]);
+  });
+  return str.replace(regex, (match: string) => {
+    return remote2local.get(match);
+  });
 }
 
 export function isUrl(link: string) {


### PR DESCRIPTION
Encountered several times the duplicate & mismatch problem raised in #24.

Figured the `str.replace` might somehow return matches in different orders each time it's called. Zip the (remote url, promise) pairs into a map, make the second `str.replace` call look up the promise result corresponding to the matched remote url, problem fixed.