### PR TITLE
fix: replace %20 of filename

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,7 @@ export const NOTICE_TIMEOUT = 10 * 1000;
 
 export const TIMEOUT_LIKE_INFINITY = 24 * 60 * 60 * 1000;
 
-export const FORBIDDEN_SYMBOLS_FILENAME_PATTERN = /\s+/g;
+export const FORBIDDEN_SYMBOLS_FILENAME_PATTERN = /\s+|%20/g;
 export interface ISettings {
   realTimeUpdate: boolean;
   realTimeUpdateInterval: number;


### PR DESCRIPTION
The plugin will not generate the right image tag if the image URL like `http://pic.ftium4.com/2021%2012%2027%2016406148378569.gif`